### PR TITLE
Add support for config directory CLI argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,17 @@ crashlytics.properties
 crashlytics-build.properties
 fabric.properties
 
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# Config ignore
+firetail/config.py
+
+# Distribution / packaging
+develop-eggs/
+eggs/
+*.egg-info/
+.installed.cfg
+*.egg
+.vscode/

--- a/firetail/core/bot.py
+++ b/firetail/core/bot.py
@@ -2,12 +2,19 @@ import discord
 from discord.ext import commands
 
 import os
+import sys
 import aiohttp
 from collections import Counter
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
 
-from firetail import config
+if os.environ.get('FTCONFIG') is not None:
+    print("CUSTOM CONFIG DIR: " + os.environ['FTCONFIG'])
+    sys.path.insert(0, os.environ['FTCONFIG'])
+    import config
+else:
+    from firetail import config
+
 from firetail.lib import ESI
 from firetail.utils import ExitCodes
 

--- a/firetail/core/bot.py
+++ b/firetail/core/bot.py
@@ -9,7 +9,6 @@ from datetime import datetime
 from dateutil.relativedelta import relativedelta
 
 if os.environ.get('FTCONFIG') is not None:
-    print("CUSTOM CONFIG DIR: " + os.environ['FTCONFIG'])
     sys.path.insert(0, os.environ['FTCONFIG'])
     import config
 else:

--- a/firetail/core/events.py
+++ b/firetail/core/events.py
@@ -4,7 +4,6 @@ import traceback
 import aiohttp
 
 from discord.ext import commands
-from firetail import config
 from firetail.lib import db
 
 import firetail
@@ -41,7 +40,7 @@ def init_events(bot, launcher=None):
         if bot.invite_url:
             print("\nInvite URL: {}\n".format(bot.invite_url))
             try:
-                db_token = config.db_token
+                db_token = bot.config.db_token
                 url = "https://discordbots.org/api/bots/{}/stats".format(bot.user.id)
                 headers = {"Authorization": db_token}
                 payload = {"server_count": len(bot.guilds)}
@@ -118,7 +117,7 @@ def init_events(bot, launcher=None):
     async def on_guild_join(guild):
         log.info("Connected to a new guild. Guild ID/Name: {}/{}".format(str(guild.id), guild.name))
         try:
-            db_token = config.db_token
+            db_token = bot.config.db_token
             url = "https://discordbots.org/api/bots/{}/stats".format(bot.user.id)
             headers = {"Authorization": db_token}
             payload = {"server_count": len(bot.guilds)}
@@ -131,7 +130,7 @@ def init_events(bot, launcher=None):
     async def on_guild_remove(guild):
         log.info("Leaving guild. Guild ID/Name: {}/{}".format(str(guild.id), guild.name))
         try:
-            db_token = config.db_token
+            db_token = bot.config.db_token
             url = "https://discordbots.org/api/bots/{}/stats".format(bot.user.id)
             headers = {"Authorization": db_token}
             payload = {"server_count": len(bot.guilds)}

--- a/firetail/launcher.py
+++ b/firetail/launcher.py
@@ -1,16 +1,29 @@
 import sys
+import os
 import argparse
 import subprocess
 
+class ArgumentParser(argparse.ArgumentParser):
+    def __is_valid_directory(self, parser, arg):
+        if not os.path.isdir(arg):
+            parser.error('Directory {} not found.'.format(arg))
+        else:
+            return arg
+
+    def add_argument_with_dir_check(self, *args, **kwargs):
+        kwargs['type'] = lambda x: self.__is_valid_directory(self, x)
+        self.add_argument(*args, **kwargs)
 
 def parse_cli_args():
-    parser = argparse.ArgumentParser(
+    parser = ArgumentParser(
         description="Firetail - An EVE Online Discord Bot")
     parser.add_argument(
         "--no-restart", "-r",
         help="Disables auto-restart.", action="store_true")
     parser.add_argument(
         "--debug", "-d", help="Enabled debug mode.", action="store_true")
+    parser.add_argument_with_dir_check(
+        "--config", help="Directory with config.py file.")
     return parser.parse_known_args()
 
 
@@ -36,10 +49,15 @@ def main():
     if launch_args.debug:
         ft_args.append('-d')
 
+    if launch_args.config:
+        env = dict(os.environ, FTCONFIG=launch_args.config)
+    else:
+        env = os.environ
+
     ft_args.append('-l')
 
     while True:
-        code = subprocess.call(["firetail-bot", *ft_args])
+        code = subprocess.call(["firetail-bot", *ft_args], env=env)
         if code == 0:
             print("Goodbye!")
             break
@@ -52,3 +70,6 @@ def main():
             print("I crashed! Trying to restart...\n")
     print("Exit code: {exit_code}".format(exit_code=code))
     sys.exit(code)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Apparently this is helpful or something.

To use:
```bash
firetail --config A:/Directory/Here/I/Guess
```

How it works:
Launcher starts the bot as a subprocess already. Just pass in an environmental variable for that process that the bot script is looking for. If it find it has been set, it'll add it's value to the top of the sys.paths and `import config` should find the file as it's looking through the paths. 