### PR TITLE
Don't fail about command if memory_usage can't be checked

### DIFF
--- a/firetail/core/commands.py
+++ b/firetail/core/commands.py
@@ -506,6 +506,8 @@ def memory_usage():
             key = parts[0][2:-1].lower()
             if key in result:
                 result[key] = int(parts[1])
+    except:
+        pass
     finally:
         if status is not None:
             status.close()


### PR DESCRIPTION
In the case of the `about` command failing to check `/proc/self/status`, due to non-Linux OS, simply suppress the error and report memory usage as 0.