### PR TITLE
Ignore log files and SQLite file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,10 @@ __pycache__/
 # Config ignore
 firetail/config.py
 
+# Data ignore
+firetail/logs/*
+firetail.sqlite
+
 # Distribution / packaging
 develop-eggs/
 eggs/


### PR DESCRIPTION
Aids in easy git pushes by ignoring generated log files and the SQLite data file.