### PR TITLE
Fix Prefix Checks and Checks Inheritance

### DIFF
--- a/firetail/core/checks.py
+++ b/firetail/core/checks.py
@@ -9,17 +9,35 @@ async def check_is_owner(ctx):
 
 
 async def check_is_co_owner(ctx):
-    owner = ctx.author.id in ctx.bot.co_owners
-    co_owner = await ctx.bot.is_owner(ctx.author)
-    return owner or co_owner
+    if await check_is_owner(ctx):
+        return True
+    if ctx.author.id in ctx.bot.co_owners:
+        return True
+    return False
+
+
+async def check_is_guildowner(ctx):
+    if await check_is_co_owner(ctx):
+        return True
+    if ctx.author.id == ctx.guild.owner.id:
+        return True
+    return False
 
 
 async def check_is_admin(ctx):
-    return ctx.author.guild_permissions.administrator
+    if await check_is_guildowner(ctx):
+        return True
+    if ctx.author.guild_permissions.manage_guild:
+        return True
+    return False
 
 
 async def check_is_mod(ctx):
-    return ctx.channel.permissions_for(ctx.author).manage_messages
+    if await check_is_admin(ctx):
+        return True
+    if ctx.channel.permissions_for(ctx.author).manage_messages:
+        return True
+    return False
 
 
 async def check_spam(ctx):
@@ -102,6 +120,10 @@ def is_owner():
 
 def is_co_owner():
     return commands.check(check_is_co_owner)
+
+
+def is_guild_owner():
+    return commands.check(check_is_guildowner)
 
 
 def is_admin():

--- a/firetail/core/commands.py
+++ b/firetail/core/commands.py
@@ -420,7 +420,6 @@ class Core:
             await ctx.send(embed=embed)
 
     @commands.command(name="prefix")
-    @checks.is_co_owner()
     @checks.spam_check()
     async def _prefix(self, ctx, *, new_prefix: str = None):
         """Get and set server prefix.
@@ -443,16 +442,21 @@ class Core:
                 msg_type='info', title="Prefix is {}".format(prefix))
             return await ctx.send(embed=embed)
 
-        await db.execute_sql(
-            "INSERT OR REPLACE INTO prefixes(guild_id, prefix)"
-            "VALUES(?, ?)", (ctx.guild.id, new_prefix))
+        if await checks.check_is_admin(ctx):
+            await db.execute_sql(
+                "INSERT OR REPLACE INTO prefixes(guild_id, prefix)"
+                "VALUES(?, ?)", (ctx.guild.id, new_prefix))
 
-        ctx.bot.prefixes[ctx.guild.id] = new_prefix
+            ctx.bot.prefixes[ctx.guild.id] = new_prefix
+
+            embed = utils.make_embed(
+                msg_type='info', title="Prefix set to {}".format(new_prefix))
+            return await ctx.send(embed=embed)
 
         embed = utils.make_embed(
-            msg_type='info', title="Prefix set to {}".format(new_prefix))
+            msg_type='error',
+            title="Prefix can only be set by admins.")
         return await ctx.send(embed=embed)
-
 
     @commands.command(name="whitelist")
     @checks.is_admin()


### PR DESCRIPTION
The bot checks were not correctly inheriting previously, as a person who passes higher level checks should pass all lower level ones.

Added `guildowner` check level.

Removes the co-owner level check from the `prefix` command.
Adds a `admin` level check when a prefix change has been requested, and returns error if check not passed.