### PR TITLE
Correctly Reference Results Length

### DIFF
--- a/firetail/lib/esi.py
+++ b/firetail/lib/esi.py
@@ -47,7 +47,7 @@ class ESI:
             return None
 
         # if multiple, try stricter search
-        if len(data) > 1:
+        if len(data[category]) > 1 and not force_strict:
             strict_data = await self.get_data(url.format(
                 ESI_URL, category, item, 'true'))
 


### PR DESCRIPTION
Forgot to check length of results list within the category value, rather than the results dict length. 

Previous, it would never check with `strict` parameter unless it had more than one category return, which we actually wanted when more than one value returned.

For good measure, skipped the unnecessary second strict request if force_strict flag was True, as the initial request would have been strict already, making the results exactly the same and a waste.