### PR TITLE
Modify Timezone Notation AEST to AEDT

### DIFF
--- a/firetail/extensions/eve_time/eve_time.py
+++ b/firetail/extensions/eve_time/eve_time.py
@@ -20,7 +20,7 @@ class EveTime:
         'EST/New York': 'America/New_York',
         'CET/Copenhagen': 'Europe/Copenhagen',
         'MSK/Moscow': 'Europe/Moscow',
-        'AEST/Sydney': 'Australia/Sydney',
+        'AEDT/Sydney': 'Australia/Sydney',
     }
 
     @commands.command(name='time')


### PR DESCRIPTION
Sydney Timezone should be notated as AEDT, or Australian Eastern Daylight Time.

https://www.timeanddate.com/time/zones/aedt

Although sydney swaps between AEST and AEDT, it is commonly only referred to as AEDT to distinguish itself from half of the east coast that does not observe DST and is AEST all year round.
https://www.timeanddate.com/time/zone/australia/sydney

or see more 
https://www.australia.gov.au/about-australia/facts-and-figures/time-zones-and-daylight-saving